### PR TITLE
Fixed import statements for React ^0.28

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -62,9 +62,12 @@ export default class TimePicker extends Component {
 		return m % 60;
 	};
 
-	_onValueChangeCallback = () => {
+	_onValueChangeCallback = (newHour, newMin) => {
 		if ('onValueChange' in this.props) {
-			this.props.onValueChange(this._getHourValue(this.state.selectedHour), this._getMinuteValue(this.state.selectedMinute));
+			this.props.onValueChange(
+				this._getHourValue((newHour !== null) ? newHour : this.state.selectedHour),
+				this._getMinuteValue((newMin !== null) ? newMin : this.state.selectedMinute)
+			);
 		}
 	};
 
@@ -73,7 +76,7 @@ export default class TimePicker extends Component {
 			selectedHour: hour
 		});
 
-		this._onValueChangeCallback();
+		this._onValueChangeCallback(hour, null);
 	};
 
 	_setMinute = (minute) => {
@@ -81,7 +84,7 @@ export default class TimePicker extends Component {
 			selectedMinute: minute
 		});
 
-		this._onValueChangeCallback();
+		this._onValueChangeCallback(null, minute);
 	};
 
 	render() {

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,12 +1,16 @@
 'use strict';
 
 import React, { Component } from 'react';
-import {
+
+import 
+{
 	AppRegistry,
 	View,
 	PickerIOS,
-	StyleSheet
+	StyleSheet,
+
 } from 'react-native';
+
 
 export default class TimePicker extends Component {
 	constructor(props) {
@@ -58,9 +62,9 @@ export default class TimePicker extends Component {
 		return m % 60;
 	};
 
-	_onValueChangeCallback = (hour, minute) => {
+	_onValueChangeCallback = () => {
 		if ('onValueChange' in this.props) {
-			this.props.onValueChange(hour, minute);
+			this.props.onValueChange(this._getHourValue(this.state.selectedHour), this._getMinuteValue(this.state.selectedMinute));
 		}
 	};
 
@@ -69,7 +73,7 @@ export default class TimePicker extends Component {
 			selectedHour: hour
 		});
 
-		this._onValueChangeCallback(this._getHourValue(hour), this._getMinuteValue(this.state.selectedMinute));
+		this._onValueChangeCallback();
 	};
 
 	_setMinute = (minute) => {
@@ -77,7 +81,7 @@ export default class TimePicker extends Component {
 			selectedMinute: minute
 		});
 
-		this._onValueChangeCallback(this._getHourValue(this.state.selectedHour), this._getMinuteValue(minute));
+		this._onValueChangeCallback();
 	};
 
 	render() {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,19 @@
 {
-  "name": "react-native-timepicker",
-  "version": "1.0.3",
+  "name": "@athletiscope/react-native-timepicker",
+  "version": "0.0.2",
   "main": "index.ios.js",
-  "author": "Rokas Milasevicius <rokas@milasevicius.com> (http://milasevicius.com)",
-  "repository": "milasevicius/react-native-timepicker",
-  "license": "MIT"
+  "author": "Athletigen Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/goredefex/react-native-timepicker"
+  },
+  "license": "MIT",
+  "description": "React native custom timepicker (24 hours format) for iOS",
+  "bugs": {
+    "url": "https://github.com/goredefex/react-native-timepicker/issues"
+  },
+  "homepage": "https://github.com/goredefex/react-native-timepicker#readme",
+  "scripts": {
+    "test": "test"
+  }
 }


### PR DESCRIPTION
Converted the header implementations of index.ios.js to be compatible with current React / React-native code standards and requirements. I changed the component destructor to the proper package.
